### PR TITLE
Fix(plugin.yml): Hapus spasi dari nama plugin

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: Karta PetsPlus
+name: KartaPetsPlus
 version: '${project.version}'
 main: com.karta.petsplus.KartaPetsPlus
 api-version: '1.21'


### PR DESCRIPTION
Error `InvalidDescriptionException` terjadi karena nama plugin di `plugin.yml` ('Karta PetsPlus') mengandung spasi.

Perubahan ini menghapus spasi tersebut, mengubah nama menjadi 'KartaPetsPlus' untuk mengatasi masalah saat memuat plugin.