### PR TITLE
Fix compilation errors in PurchaseHandler and PetsCommand

### DIFF
--- a/src/main/java/com/karta/petsplus/PetManager.java
+++ b/src/main/java/com/karta/petsplus/PetManager.java
@@ -69,7 +69,7 @@ public class PetManager implements Listener {
         });
     }
 
-    private void savePlayerData(UUID uuid) {
+    void savePlayerData(UUID uuid) {
         PetData data = playerDataCache.get(uuid);
         if (data != null) {
             if (!activePets.containsKey(uuid)) {

--- a/src/main/java/com/karta/petsplus/PurchaseHandler.java
+++ b/src/main/java/com/karta/petsplus/PurchaseHandler.java
@@ -48,7 +48,7 @@ public class PurchaseHandler {
 
             if (economyManager.withdraw(player, price)) {
                 petData.addOwnedPet(petKey);
-                petManager.savePlayerData(player.getUniqueId(), petData);
+                petManager.savePlayerData(player.getUniqueId());
                 player.sendMessage(messageManager.getMessage("pet-purchase-success").replace("{pet_name}", petSection.getString("name")));
             } else {
                 player.sendMessage(messageManager.getMessage("purchase-failed"));

--- a/src/main/java/com/karta/petsplus/commands/PetsCommand.java
+++ b/src/main/java/com/karta/petsplus/commands/PetsCommand.java
@@ -3,6 +3,7 @@ package com.karta.petsplus.commands;
 import com.karta.petsplus.PetData;
 import com.karta.petsplus.PetManager;
 import com.karta.petsplus.PetsPlus;
+import com.karta.petsplus.ShopMenu;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;


### PR DESCRIPTION
This commit fixes three compilation errors:
1. The `savePlayerData` method in `PetManager` was called with an incorrect number of arguments from `PurchaseHandler`. The method call is updated to pass only the player's UUID.
2. The `savePlayerData` method in `PetManager` was `private`, preventing it from being called from `PurchaseHandler`. The visibility is changed to package-private.
3. The `ShopMenu` class was not imported in `PetsCommand`, causing a "cannot find symbol" error. The missing import has been added.